### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/chat_app/db/database.py
+++ b/chat_app/db/database.py
@@ -751,8 +751,7 @@ def create_default_admin_user_if_not_exists():
 
             if register_user(default_admin_username, password_hash, is_admin=1):
                 current_app.logger.info(f"Default admin user created - username: {default_admin_username}")
-                print(
-                    f"Default admin user '{default_admin_username}' created with password '{default_admin_password}'. 请立即修改密码！")
+                current_app.logger.info(f"Default admin user '{default_admin_username}' created. 请立即修改密码！")
                 return # 创建成功, 返回
             else:
                 current_app.logger.warning(f"Failed to create default admin user (username might exist)") # 记录创建失败信息


### PR DESCRIPTION
Potential fix for [https://github.com/Dehou23333-awa/DCR/security/code-scanning/1](https://github.com/Dehou23333-awa/DCR/security/code-scanning/1)

To fix the problem, we need to ensure that sensitive information, such as passwords, is not logged in clear text. Instead of logging the password, we can log a message indicating that the default admin user was created and instruct the user to change the password immediately. This way, we avoid exposing the password in the logs while still providing useful information.

- Remove the line that logs the default admin password in clear text.
- Replace it with a message that instructs the user to change the password immediately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
